### PR TITLE
reorder

### DIFF
--- a/modules/shortlinks.py
+++ b/modules/shortlinks.py
@@ -64,12 +64,12 @@ def twlink(bot, trigger):
 def mhwiki(bot, trigger):
     try:
         options = trigger.group(2).split(" ")
+        if len(options) == 1:
+            page = options[0]
+            bot.say("https://meta.miraheze.org/wiki/" + page)
+        elif len(options) == 2:
+            wiki = options[0]
+            page = options[1]
+            bot.say("https://" + wiki + ".miraheze.org/wiki/" + page)
     except AttributeError:
         bot.say('Syntax: .mh wiki page', trigger.sender)
-    if len(options) == 1:
-        page = options[0]
-        bot.say("https://meta.miraheze.org/wiki/" + page)
-    elif len(options) == 2:
-        wiki = options[0]
-        page = options[1]
-        bot.say("https://" + wiki + ".miraheze.org/wiki/" + page)


### PR DESCRIPTION
due to:
23:43:27 <RhinosF1> .mh
23:43:27 <+ZppixBot> Syntax: .mh wiki page
23:43:29 <+ZppixBot> [irc.py] Exception from #ZppixBot: UnboundLocalError: local variable 'options' referenced before assignment (file "/data/project/zppixbot/.sopel/modules/shortlinks.py", line 69, in mhwiki) (:RhinosF1!uid339563@miraheze/RhinosF1 PRIVMSG #ZppixBot :.mh)