### PR TITLE
[T241411] Don’t validate auth for removal of own rights

### DIFF
--- a/modules/channelmgnt.py
+++ b/modules/channelmgnt.py
@@ -95,8 +95,8 @@ def deop(bot, trigger):
     nick = trigger.group(2)
     channel = trigger.sender
     if not nick:
-        nick = trigger.nick
-    if trigger.account in chanops:
+        bot.write(['MODE', channel, "-o", trigger.nick])
+    elif trigger.account in chanops:
         bot.write(['MODE', channel, "-o", nick])
     else:
         bot.reply('Access Denied. If in error, please contact the channel founder.')
@@ -137,8 +137,8 @@ def devoice(bot, trigger):
     nick = trigger.group(2)
     channel = trigger.sender
     if not nick:
-        nick = trigger.nick
-    if trigger.account in chanops:
+        bot.write(['MODE', channel, "-v", trigger.nick])
+    elif trigger.account in chanops:
         bot.write(['MODE', channel, "-v", nick])
     else:
         bot.reply('Access Denied. If in error, please contact the channel founder.')


### PR DESCRIPTION
will allow someone opped up by an op to do something temporary for whatever reason to quickly remove own rights after making it easier for everyone.