### PR TITLE
Update SECURITY

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ZppixBot uses [Sopel](https://sopel.chat).
 To use this bot, copy `modules` folder to your Sopel installation
 (and don't forget to setup your `default.cfg` if needed)
 
-Please note that in line with our security policy, we can only support Sopel 7.x installations running Python 3.
+Please note that in line with our security policy, we can only support Sopel 7.x installations running Python 3.5+.
 
 [Source Github](http://github.com/sopel-irc/sopel)
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ ZppixBot uses [Sopel](https://sopel.chat).
 To use this bot, copy `modules` folder to your Sopel installation
 (and don't forget to setup your `default.cfg` if needed)
 
+Please note that in line with our security policy, we can only support Sopel 7.x installations running Python 3.
+
 [Source Github](http://github.com/sopel-irc/sopel)
 
 [More info](https://zppixbot.toolforge.org/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-We currently support the following versions with security releases when running sopel 7.x on python 3.x:
+We currently support the following versions with security releases when running sopel 7.x on python 3.5+:
 
 | Version | Supported          |
 | ------- | ------------------ |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,14 +2,14 @@
 
 ## Supported Versions
 
-We currently support the following versions with security releases:
+We currently support the following versions with security releases when running sopel 7.x on python 3.x:
 
 | Version | Supported          |
 | ------- | ------------------ |
 | master  | :white_check_mark: |
-| 5       | :white_check_mark: |
-| 4       | :white_check_mark: |
-| < 4.0   | :x:                |
+| dev     |                    |
+| 6       | :white_check_mark: |
+| < 6.0   | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Only support sopel 7 running python 3 and latest ZppixBot

This drops support for
Sopel <7
Python <3.5
ZppixBot <6