### PR TITLE
update chanop lists

### DIFF
--- a/modules/channelmgnt.py
+++ b/modules/channelmgnt.py
@@ -38,23 +38,21 @@ def get_chanops(bot, trigger):
     elif str(trigger.sender) == '#miraheze' or str(trigger.sender) == '#miraheze-offtopic':
         chanops = ['Southparkfan', 'Zppix', 'NDKilla', 'labster', 'Reception123', 'Voidwalker', 'Void|bot', 'JohnLewis', 'Paladox']
     elif str(trigger.sender) == '#miraheze-cvt' or str(trigger.sender) == '#miraheze-cvt-private':
-        chanops = ['NDKilla', 'Voidwalker', 'Reception123', 'Zppix', 'The_Pionner', 'JohnLewis']
+        chanops = ['NDKilla', 'Voidwalker', 'Reception123', 'The_Pionner', 'JohnLewis']
     elif str(trigger.sender) == '#miraheze-testwiki':
-        chanops = ['Reception123', 'NDKilla', 'Voidwalker']
+        chanops = ['Reception123', 'NDKilla', 'Voidwalker', 'Zppix', 'RhinosF1']
     elif str(trigger.sender) == '#miraheze-testwiki-es':
-        chanops = ['AlvaroMolina', 'Reception123', 'NDKilla', 'Voidwalker']
+        chanops = ['Reception123', 'NDKilla', 'Voidwalker']
     elif str(trigger.sender) == '#ZppixBot' or str(trigger.sender) == '#ZppixBot-logs':
-        chanops = ['Zppix', 'Reception123', 'Voidwalker']
+        chanops = ['Zppix', 'Reception123', 'Voidwalker', 'RhinosF1']
     elif str(trigger.sender) == '#testadminwiki':
-        chanops = ['MacFan4000', 'Voidwalker', 'AlvaroMolina']
+        chanops = ['MacFan4000', 'Voidwalker']
     elif str(trigger.sender) == '##CyberBogan':
         chanops = ['NeoBogan', 'Oshwah', 'enterprisey', 'Havyk', 'Athyria', 'LakesideMiners', 'foks', 'Jobe', 'MarxLenin99', 'SQLDb', 'TxHadriel', 'ShakespeareFan00', 'Zppix', 'KSFT']
     elif str(trigger.sender) == '##Zppix-Wikipedia':
         chanops = ['Zppix', 'tom29739', 'SwisterTwister', 'Snowycats', 'DatGuy', 'mattwj2002']
     elif str(trigger.sender) == '#ays':
         chanops = ['Mbrt', 'Arifys', 'Murbaut']
-    elif str(trigger.sender) == '#miraheze-meetings':
-        chanops = ['Paladox', 'RhinosF1', 'Voidwalker', 'SPF|Cloud']
     else:
         bot.say('Please ask in #ZppixBot for assistance configuring the channel management module.', trigger.sender)
     return chanops

--- a/modules/miraheze.py
+++ b/modules/miraheze.py
@@ -41,7 +41,7 @@ def miraheze(bot, trigger):
 def miraheze_gethelp(bot, trigger):
     """Reply to help requests."""
     if trigger.sender == '#miraheze':
-        bot.reply(trigger.nick + ', needs help. Pinging Reception123, Zppix, '
+        bot.say(trigger.nick + ', needs help. Pinging Reception123, Zppix, '
                   'PuppyKun, Voidwalker, RhinosF1.')
     else:
         bot.reply('If you need Miraheze releated help, please join #miraheze')


### PR DESCRIPTION
#miraheze-cvt, and -private: Zppix is no longer cvt/globalsysop
#miraheze-testwiki: Zppix and RhinosF1 are consuls and now have flags
#miraheze-testwiki-es and #testadminwiki: The AlvaroMolina nick was dropped during freenode server cleanup
#ZppixBot: RhinosF1 is a maintainer and has flags
#miraheze-meetings: the bot is no longer in this channel per f9b5d3e